### PR TITLE
재난문자내역조회 기능 추가

### DIFF
--- a/capstone/lib/message_api.dart
+++ b/capstone/lib/message_api.dart
@@ -1,0 +1,50 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+Future<List<Map<String, dynamic>>> fetchDisasterMessages() async {
+  final serviceKey = 'WX6MKDO0M27K76GF';
+
+  // 오늘 날짜 계산 (YYYYMMDD)
+//  final now = DateTime.now();
+
+  // final today =      '${now.year}${now.month.toString().padLeft(2, '0')}${now.day.toString().padLeft(2, '0')}';
+  // 어제 날짜 계산 (필요시 조회범위 확장)
+  // final yesterday = now.subtract(const Duration(days: 1));
+  // final startDate =      '${yesterday.year}${yesterday.month.toString().padLeft(2, '0')}${yesterday.day.toString().padLeft(2, '0')}';
+
+  // URL 생성 (오늘날짜 데이터만)
+  final url = Uri.parse('https://www.safetydata.go.kr/V2/api/DSSP-IF-00247'
+      '?serviceKey=$serviceKey'
+      '&pageNo=1'
+      '&numOfRows=1000'
+      '&crtDt=20250101'
+      '&rgnNm=서울특별시');
+
+  final response = await http.get(url);
+
+  // 디버깅용 로그
+  print('응답 status: ${response.statusCode}');
+  final decodedString = utf8.decode(response.bodyBytes);
+  print('응답 body (decoded): $decodedString');
+
+  // 정상응답일 때만 파싱
+  if (response.statusCode == 200) {
+    final data = jsonDecode(decodedString);
+    final List bodyList = data['body'] ?? [];
+    // 파싱 및 맵 변환
+    final parsedMessages = bodyList
+        .map<Map<String, dynamic>>((item) => {
+              'sender': item['RCPTN_RGN_NM'] ?? 'Unknown',
+              'time': item['CRT_DT'] ?? '',
+              'content': item['MSG_CN'] ?? '',
+            })
+        .toList();
+    // 최신순 정렬(시간 기준으로 내림차순)
+    parsedMessages
+        .sort((a, b) => (b['time'] as String).compareTo(a['time'] as String));
+    return parsedMessages;
+  } else {
+    print('API 오류: ${response.statusCode}');
+    return [];
+  }
+}

--- a/capstone/lib/message_ui.dart
+++ b/capstone/lib/message_ui.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'message_api.dart';
 
 class MessageScreen extends StatefulWidget {
   const MessageScreen({Key? key}) : super(key: key);
@@ -9,26 +10,20 @@ class MessageScreen extends StatefulWidget {
 
 class _MessageScreenState extends State<MessageScreen> {
   // 샘플 데이터 (API 연동 시 setState로 갱신)
-  List<Map<String, dynamic>> messages = [
-    {
-      'sender': 'Jongno-gu',
-      'time': 'now',
-      'content':
-          'Earthquake disaster training message has been delivered.\nThis is a training message. It is not a real situation.\nThis is an error that occurred during the process of delivering a training message, not a real earthquake situation. We will fix it.',
-    },
-    {
-      'sender': 'Forestry Service',
-      'time': '3 hours ago',
-      'content':
-          "Today at 9 p.m., a landslide crisis warning level 'Caution' has been issued in Seoul and other areas.\nResidents and visitors in landslide-prone areas, etc. are requested to evacuate to a safe place in case of emergency.",
-    },
-    {
-      'sender': 'Seoul Metropolitan Government',
-      'time': '7 hours ago',
-      'content':
-          "Currently, an emergency accident has occurred in front ...", // 예시
-    },
-  ];
+  List<Map<String, dynamic>> messages = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _loadDisasterMessages();
+  }
+
+  Future<void> _loadDisasterMessages() async {
+    final fetchedMessages = await fetchDisasterMessages();
+    setState(() {
+      messages = fetchedMessages;
+    });
+  }
 
   // 메시지 삭제 함수
   void _removeMessage(int index) {


### PR DESCRIPTION
재난문자내역조회 기능 추가함
api 최대 호출량이 1000개까지 가능해서 1000개라서
이게 2024년 1월부터 끌어오면 24년 9월까지 되고, 최근 문자가 안 떠서
25년 1월부터 1000개 호출로 끌어옴.
지역은 서울특별시로 제한함. 나중에 수정 필요하면 토의